### PR TITLE
Add minimal DSCA example backend for dev/testing

### DIFF
--- a/dev/org/bdinetwork/example/backend.clj
+++ b/dev/org/bdinetwork/example/backend.clj
@@ -1,0 +1,44 @@
+;;; SPDX-FileCopyrightText: 2025 Jomco B.V.
+;;; SPDX-FileCopyrightText: 2025 Topsector Logistiek
+;;; SPDX-FileContributor: Joost Diepenmaat <joost@jomco.nl>
+;;; SPDX-FileContributor: Remco van 't Veer <remco@jomco.nl>
+;;;
+;;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+(ns org.bdinetwork.example.backend
+  "An example API server without authentication / authorization.
+
+  The backend API returns DSCA events at /v3/events endpoint.
+
+  The BDI Connector can be configured to authenticate and authorize
+  incoming requests."
+  (:require [clojure.java.io :as io]
+            [compojure.core :refer [GET routes]]
+            [compojure.route :as route]
+            [nl.jomco.http-status-codes :as status]
+            [nl.jomco.resources :refer [mk-system Resource]]
+            [ring.adapter.jetty :refer [run-jetty]]))
+
+(extend-protocol Resource
+  org.eclipse.jetty.server.Server
+  (close [server]
+    (.stop server)))
+
+(defn content
+  []
+  (slurp (io/resource "org/bdinetwork/example/backend/response.json")))
+
+(defn mk-handler
+  []
+  (routes
+   (GET "/v3/events" [_]
+     {:status status/ok
+      :headers {"content-type" "application/json"}
+      :body (content)})
+   (route/not-found "Not found")))
+
+(defn start
+  [{:keys [port hostname] :or {hostname "localhost"}}]
+  {:pre [port hostname]}
+  (mk-system [handler (mk-handler)
+              jetty (run-jetty handler {:join? false :port port :hostname hostname})]))

--- a/dev/org/bdinetwork/example/backend/response.json
+++ b/dev/org/bdinetwork/example/backend/response.json
@@ -1,0 +1,122 @@
+[
+  {
+    "metadata": {
+      "eventID": "ID1",
+      "eventType": "EQUIPMENT"
+    },
+    "payload": {
+      "eventClassifierCode": "ACT",
+      "eventDateTime": "2025-06-06T16:29:00+0200",
+      "equipmentEventTypeCode": "GTOUT",
+      "equipmentReference": "MRKU0674130",
+      "emptyIndicatorCode": "LADEN",
+      "eventLocation": {
+        "location": {
+          "UNLocationCode": "NLRTM",
+          "facilityCode": "APMR2",
+          "facilityCodeListProvider": "SMDG"
+        }
+      }
+    }
+  },
+  {
+    "metadata": {
+      "eventID": "ID2",
+      "eventType": "EQUIPMENT"
+    },
+    "payload": {
+      "eventClassifierCode": "ACT",
+      "eventDateTime": "2025-06-07T06:00:00+0200",
+      "equipmentEventTypeCode": "GTIN",
+      "equipmentReference": "MRKU0674130",
+      "emptyIndicatorCode": "LADEN",
+      "eventLocation": {
+        "location": {
+          "UNLocationCode": "NLOSS",
+          "facilityCode": "OSS",
+          "facilityCodeListProvider": "SMDG"
+        }
+      }
+    }
+  },
+  {
+    "metadata": {
+      "eventID": "ID3",
+      "eventType": "EQUIPMENT"
+    },
+    "payload": {
+      "eventClassifierCode": "ACT",
+      "eventDateTime": "2025-06-10T07:44:00+0200",
+      "equipmentEventTypeCode": "GTOUT",
+      "equipmentReference": "MRKU0674130",
+      "emptyIndicatorCode": "LADEN",
+      "eventLocation": {
+        "location": {
+          "UNLocationCode": "NLOSS",
+          "facilityCode": "OSS",
+          "facilityCodeListProvider": "SMDG"
+        }
+      }
+    }
+  },
+  {
+    "metadata": {
+      "eventID": "ID4",
+      "eventType": "EQUIPMENT"
+    },
+    "payload": {
+      "eventClassifierCode": "ACT",
+      "eventDateTime": "2025-06-10T11:57:00+0200",
+      "equipmentEventTypeCode": "GTIN",
+      "equipmentReference": "MRKU0674130",
+      "emptyIndicatorCode": "EMPTY",
+      "eventLocation": {
+        "location": {
+          "UNLocationCode": "NLVEG",
+          "facilityCode": "VEG",
+          "facilityCodeListProvider": "SMDG"
+        }
+      }
+    }
+  },
+  {
+    "metadata": {
+      "eventID": "ID5",
+      "eventType": "EQUIPMENT"
+    },
+    "payload": {
+      "eventClassifierCode": "ACT",
+      "eventDateTime": "2025-06-11T09:15:00+0200",
+      "equipmentEventTypeCode": "GTOUT",
+      "equipmentReference": "MRKU0674130",
+      "emptyIndicatorCode": "EMPTY",
+      "eventLocation": {
+        "location": {
+          "UNLocationCode": "NLVEG",
+          "facilityCode": "VEG",
+          "facilityCodeListProvider": "SMDG"
+        }
+      }
+    }
+  },
+  {
+    "metadata": {
+      "eventID": "ID6",
+      "eventType": "EQUIPMENT"
+    },
+    "payload": {
+      "eventClassifierCode": "ACT",
+      "eventDateTime": "2025-06-12T00:47:00+0200",
+      "equipmentEventTypeCode": "GTIN",
+      "equipmentReference": "MRKU0674130",
+      "emptyIndicatorCode": "EMPTY",
+      "eventLocation": {
+        "location": {
+          "UNLocationCode": "NLRTM",
+          "facilityCode": "RCT",
+          "facilityCodeListProvider": "SMDG"
+        }
+      }
+    }
+  }
+]

--- a/dev/org/bdinetwork/example/backend/response.json.license
+++ b/dev/org/bdinetwork/example/backend/response.json.license
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2025 Jomco B.V.
+# SPDX-FileCopyrightText: 2025 Topsector Logistiek
+# SPDX-FileContributor: Joost Diepenmaat <joost@jomco.nl>
+# SPDX-FileContributor: Remco van 't Veer <remco@jomco.nl>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -21,6 +21,7 @@
             [org.bdinetwork.authentication.access-token :as access-token]
             [org.bdinetwork.authorization-register.main :as authorization-register.main]
             [org.bdinetwork.connector.main :as connector.main]
+            [org.bdinetwork.example.backend :as example-backend]
             [org.bdinetwork.ishare.client :as ishare-client]
             [org.bdinetwork.ishare.jwt :as ishare-jwt]
             [org.bdinetwork.service-commons.config :as config]))
@@ -77,6 +78,9 @@
    :association-server-id  (:server-id association-env)
    :association-server-url association-url})
 
+(def example-backend-config
+  {:port 9991})
+
 #_{:clj-kondo/ignore [:uninitialized-var]}
 (defresource system)
 
@@ -86,6 +90,7 @@
     (mk-system [association (association-register.main/start association-env)
                 authentication (authentication-service.main/start authentication-env)
                 authorization (authorization-register.main/start authorization-env)
+                example-backend (example-backend/start example-backend-config)
                 connector (connector.main/start connector-env)])))
 
 (defn stop! []
@@ -107,7 +112,7 @@
   (let [client-config (config/config client-env config/server-party-opt-specs)
         connector-url (str "http://" (:hostname connector-env) ":" (:port connector-env))]
     (-> {:throw                     false
-         :url                       (str connector-url "/test")
+         :url                       (str connector-url "/v3/events")
          :ishare/base-url           connector-url
          :ishare/client-id          (:server-id client-env)
          :ishare/server-id          (:server-id connector-env)

--- a/test-config/rules.edn
+++ b/test-config/rules.edn
@@ -10,6 +10,6 @@
           :interceptors [[logger]
                          [bdi/authenticate]
                          [reverse-proxy/forwarded-headers]
-                         [request/rewrite "http://example.com"]
+                         [request/rewrite "http://localhost:9991"]
                          [response/update update :headers assoc "x-bdi-connector" "passed"]
                          [reverse-proxy/proxy-request]]}]}


### PR DESCRIPTION
Configures the testing connector to the example backend in the dev/user namespace.

Issue `GET http://localhost:9991/v3/events` to query the backend directly.