### PR TITLE
connector: add demo/audit-log interceptor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@
 **/.nrepl-port
 **/tmp
 /.envrc
+/log/
 /policies.db/
 /rules.edn

--- a/connector/deps.edn
+++ b/connector/deps.edn
@@ -10,8 +10,10 @@
         aleph/aleph                    {:mvn/version "0.8.3"}
         nl.jomco/clj-http-status-codes {:mvn/version "0.1"}
 
-        ring/ring-core {:mvn/version "1.14.2"}
-        ring/ring-json {:mvn/version "0.5.1"}
+        org.clojure/data.json {:mvn/version "2.5.1"}
+        ring/ring-core        {:mvn/version "1.14.2"}
+        ring/ring-json        {:mvn/version "0.5.1"}
+        hiccup/hiccup         {:mvn/version "2.0.0-RC5"}
 
         nl.jomco/with-resources {:mvn/version "0.1.2"}
         nl.jomco/envopts        {:mvn/version "0.0.6"}

--- a/connector/resources/logback.xml
+++ b/connector/resources/logback.xml
@@ -20,5 +20,15 @@
   <root level="${ROOT_LOG_LEVEL:-info}">
     <appender-ref ref="STDOUT" />
   </root>
+
   <logger name="org.bdinetwork.connector" level="${LOG_LEVEL:-${ROOT_LOG_LEVEL}}"/>
+
+  <appender name="audit" class="ch.qos.logback.core.FileAppender">
+    <file>${AUDIT_JSON_FILE:-audit.json}</file>
+    <encoder class="ch.qos.logback.classic.encoder.JsonEncoder"/>
+  </appender>
+
+  <logger name="org.bdinetwork.gateway.interceptors" level="info">
+    <appender-ref ref="audit" />
+  </logger>
 </configuration>

--- a/connector/src/org/bdinetwork/connector/interceptors.clj
+++ b/connector/src/org/bdinetwork/connector/interceptors.clj
@@ -9,6 +9,7 @@
             [org.bdinetwork.authentication.client-assertion :as client-assertion]
             [org.bdinetwork.authentication.in-memory-association :refer [in-memory-association read-source]]
             [org.bdinetwork.authentication.remote-association :refer [remote-association]]
+            [org.bdinetwork.connector.interceptors.audit-log :refer [audit-log-response]]
             [org.bdinetwork.gateway.interceptors :refer [->interceptor interceptor]]
             [ring.middleware.json :as ring-json]
             [ring.middleware.params :as ring-params]))
@@ -82,3 +83,14 @@
                                :association (->association config))]
      (fn [{:keys [request] :as ctx}]
        (assoc ctx :response (client-assertion-response config request))))))
+
+(defmethod ->interceptor 'demo/audit-log
+  [[id {:keys [json-file] :as opts}] _]
+  {:pre [json-file]}
+  (interceptor
+   :name (str id " " (pr-str opts))
+   :doc "Provide access to the last `:n-of-lines` (defaults to 100)
+   lines of `:json-file` (required) and render them in a HTML table."
+   :enter
+   (fn [ctx]
+     (assoc ctx :response (audit-log-response opts)))))

--- a/connector/src/org/bdinetwork/connector/interceptors/audit_log.clj
+++ b/connector/src/org/bdinetwork/connector/interceptors/audit_log.clj
@@ -1,0 +1,57 @@
+;;; SPDX-FileCopyrightText: 2025 Jomco B.V.
+;;; SPDX-FileCopyrightText: 2025 Topsector Logistiek
+;;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+(ns org.bdinetwork.connector.interceptors.audit-log
+  (:require [clojure.data.json :as json]
+            [clojure.java.io :as io]
+            [hiccup2.core :as hiccup]
+            [nl.jomco.http-status-codes :as http-status])
+  (:import (java.text SimpleDateFormat)
+           (java.util Date)))
+
+(defn- has-mdc? [{:strs [mdc]}] (seq mdc))
+
+(defn- read-lines
+  [{:keys [json-file n-of-lines] :or {n-of-lines 100}}]
+  (with-open [in (-> json-file io/file io/reader)]
+    (binding [*in* in]
+      (loop [b (list)]
+        (if-let [s (read-line)]
+          (let [d (json/read-str s)]
+            (recur (if (has-mdc? d)
+                     (take n-of-lines (cons d b))
+                     b)))
+          b)))))
+
+(defn- to-date-time [timestamp]
+  (.format (SimpleDateFormat. "yyyy/MM/dd HH:mm:ss")
+           (Date. timestamp)))
+
+(def audit-log-css "
+table{background:#fff;border-collapse: collapse;}
+th,td{padding:.5em;border:solid black 1px;}
+tr:nth-child(even){background:#eee}
+")
+
+(defn audit-log-response [opts]
+  (let [lines (read-lines opts)
+        cols  (into #{} (mapcat #(-> % (get "mdc") keys) lines))]
+    {:status  http-status/ok
+     :headers {"content-type" "text/html"}
+     :body    (-> [:html
+                    [:head [:style audit-log-css]]
+                    [:body
+                     (if (seq lines)
+                       [:table
+                        [:tr
+                         [:th "timestamp"]
+                         (for [col cols] [:th col])]
+                        (for [line lines]
+                          [:tr
+                           [:td (to-date-time (get line "timestamp"))]
+                           (for [col cols]
+                             [:td (get-in line ["mdc" col])])])]
+                       [:em "log empty"])]]
+                  hiccup/html
+                  str)}))

--- a/resources/logback-test.xml
+++ b/resources/logback-test.xml
@@ -17,7 +17,16 @@
     </encoder>
   </appender>
 
-  <root level="info">
+  <root level="${ROOT_LOG_LEVEL:-info}">
     <appender-ref ref="STDOUT" />
   </root>
+
+  <appender name="audit" class="ch.qos.logback.core.FileAppender">
+    <file>log/audit.json</file>
+    <encoder class="ch.qos.logback.classic.encoder.JsonEncoder"/>
+  </appender>
+
+  <logger name="org.bdinetwork.gateway.interceptors" level="info">
+    <appender-ref ref="audit" />
+  </logger>
 </configuration>

--- a/test-config/rules.edn
+++ b/test-config/rules.edn
@@ -2,14 +2,33 @@
 ;;; SPDX-FileCopyrightText: 2025 Topsector Logistiek
 ;;; SPDX-License-Identifier: AGPL-3.0-or-later
 
-{:rules [{:match {:uri "/connect/token"}
-          :interceptors [[logger]
-                         [bdi/connect-token]
-                         [response/update update :headers assoc "x-bdi-connector" "passed"]]}
-         {:match {:headers {"user-agent" user-agent}}
-          :interceptors [[bdi/authenticate]
-                         [logger x-bdi-client-id user-agent]
-                         [reverse-proxy/forwarded-headers]
-                         [request/rewrite "http://localhost:9991"]
-                         [response/update update :headers assoc "x-bdi-connector" "passed"]
-                         [reverse-proxy/proxy-request]]}]}
+{:rules
+ [
+  ;; example access to audit log protected by basic
+  ;; authentication (for demo purposes only!)
+  {:match        {:headers {"authorization" #join ["Basic " #b64 "demo:test123"]}
+                  :uri     "/audit-log"}
+   :interceptors [[demo/audit-log {:json-file "log/audit.json"}]]} ;; as configured in logback.xml
+  {:match        {:uri "/audit-log"}
+   :interceptors [[respond {:status  401
+                            :headers {"content-type"     "text/html"
+                                      "www-authenticate" "Basic realm=\"audit\""}
+                            :body    "<html><body><em>not allowed</em><body></html>"}]]}
+  {:match        {:uri "/favicon.ico"} ;; prevent chrome for asking for basic auth again
+   :interceptors [[respond {:status 204}]]}
+
+  ;; add endpoint to get access token and pass the rest to
+  ;; backend (when authenticated)
+  {:match        {:uri "/connect/token"}
+   :interceptors [[logger]
+                  [bdi/connect-token]
+                  [response/update update :headers assoc "x-bdi-connector" "passed"]]}
+  {:match        {:request-method request-method
+                  :uri            uri}
+   :interceptors [[bdi/authenticate]
+                  ;; logged properties end up in audit log
+                  [logger x-bdi-client-id uri request-method]
+                  [reverse-proxy/forwarded-headers]
+                  [request/rewrite "http://localhost:9991"]
+                  [response/update update :headers assoc "x-bdi-connector" "passed"]
+                  [reverse-proxy/proxy-request]]}]}


### PR DESCRIPTION
Renders content of JSON logfile MDC values in a HTML table for demo purposes.
![screenshot-2025-06-17_16-38-1750171118](https://github.com/user-attachments/assets/772afe15-a787-4188-a933-bda84fabca0d)
