### PR TITLE
connector: return 403 Forbidden when delegation evidence verification fails

### DIFF
--- a/connector/src/org/bdinetwork/connector/interceptors.clj
+++ b/connector/src/org/bdinetwork/connector/interceptors.clj
@@ -108,8 +108,8 @@
    :name (str id " delegation-chain")
    :args [base-request-expr mask-expr]
    :doc "Retrieves and evaluates delegation evidence for
-   request. Responds with 401 Unauthorized when the evidence is not
-   found or does not match the delegation mask."
+   request. Responds with 403 Forbidden when the evidence is not found
+   or does not match the delegation mask."
    :enter
    (fn delegation-chain-enter
      [ctx base-request mask]
@@ -121,6 +121,6 @@
                            :delegation-issues issues)]
        (cond-> ctx
          issues
-         (assoc :response (-> response/unauthorized
+         (assoc :response (-> response/forbidden
                               (assoc-in [:headers "content-type"] "application/json")
                               (assoc :body (json/json-str {:delegation-issues issues})))))))))


### PR DESCRIPTION
> A 401 Unauthorized is similar to the 403 Forbidden
> response, except that a 403 is returned when a request
> contains valid credentials, but the client does not have
> permissions to perform a certain action.

Source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/401